### PR TITLE
Add tests for com.kennycason.kumo.font.scale.*

### DIFF
--- a/kumo-core/src/test/java/com/kennycason/kumo/font/scale/LinearFontScalarTest.java
+++ b/kumo-core/src/test/java/com/kennycason/kumo/font/scale/LinearFontScalarTest.java
@@ -1,0 +1,16 @@
+package com.kennycason.kumo.font.scale;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LinearFontScalarTest {
+
+    @Test
+    public void testScale() {
+        final LinearFontScalar fontScalar = new LinearFontScalar(-1, 13);
+        Assert.assertEquals(5.0f, fontScalar.scale(4, 1, 8), 0.0f);
+
+        final LinearFontScalar fontScalar2 = new LinearFontScalar(0, 0);
+        Assert.assertEquals(Float.NaN, fontScalar2.scale(0, 0, 0), 0.0f);
+    }
+}

--- a/kumo-core/src/test/java/com/kennycason/kumo/font/scale/LogFontScalarTest.java
+++ b/kumo-core/src/test/java/com/kennycason/kumo/font/scale/LogFontScalarTest.java
@@ -1,0 +1,16 @@
+package com.kennycason.kumo.font.scale;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogFontScalarTest {
+
+    @Test
+    public void testScale() {
+        final LogFontScalar fontScalar = new LogFontScalar(-1, 13);
+        Assert.assertEquals(9.614654f, fontScalar.scale(4, 1, 8), 0.0f);
+
+        final LogFontScalar fontScalar2 = new LogFontScalar(0, 0);
+        Assert.assertEquals(Float.NaN, fontScalar2.scale(0, 0, 0), 0.0f);
+    }
+}

--- a/kumo-core/src/test/java/com/kennycason/kumo/font/scale/SqrtFontScalarTest.java
+++ b/kumo-core/src/test/java/com/kennycason/kumo/font/scale/SqrtFontScalarTest.java
@@ -1,0 +1,16 @@
+package com.kennycason.kumo.font.scale;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SqrtFontScalarTest {
+
+    @Test
+    public void testScale() {
+        final SqrtFontScalar fontScalar = new SqrtFontScalar(-1, 13);
+        Assert.assertEquals(6.656854f, fontScalar.scale(4, 1, 8), 0.0f);
+
+        final SqrtFontScalar fontScalar2 = new SqrtFontScalar(0, 0);
+        Assert.assertEquals(Float.NaN, fontScalar2.scale(0, 0, 0), 0.0f);
+    }
+}


### PR DESCRIPTION
Hi, 
I've analysed your code base and noticed that the classes in `com.kennycason.kumo.font.scale` are not fully tested. This is according to IntelliJ's internal coverage runner

I've written tests for the `scale` functions in these classes with the help of [Diffblue](https://www.diffblue.com/) [Cover](https://www.diffblue.com/products). Hopefully, they should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.